### PR TITLE
Updating JetBrains Annotations version

### DIFF
--- a/PowerShellAsync/PowerShellAsync.csproj
+++ b/PowerShellAsync/PowerShellAsync.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations">
-      <HintPath>..\packages\ReSharper.Annotations.7.1.3.130415\lib\net\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=2018.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2018.2.1\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/PowerShellAsync/packages.config
+++ b/PowerShellAsync/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ReSharper.Annotations" version="7.1.3.130415" targetFramework="net45" />
+  <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The referenced version of Annotations is no longer available on NuGet, and the latest version works with the code written.